### PR TITLE
feat: separating transactional and non-transactional queries

### DIFF
--- a/src/main/java/io/supertokens/storage/sql/QueryExecutorTemplate.java
+++ b/src/main/java/io/supertokens/storage/sql/QueryExecutorTemplate.java
@@ -30,6 +30,10 @@ public interface QueryExecutorTemplate {
         return ConnectionPool.withConnection(start, con -> execute(con, QUERY, setter, mapper));
     }
 
+    /**
+     * This method is primarily meant to be used when you need to share connections between
+     * multiple queries for a transaction
+     */
     static <T> T execute(Connection con, String QUERY, PreparedStatementValueSetter setter,
             ResultSetValueExtractor<T> mapper) throws SQLException, StorageQueryException {
         if (setter == null)
@@ -47,6 +51,10 @@ public interface QueryExecutorTemplate {
         return ConnectionPool.withConnection(start, con -> update(con, QUERY, setter));
     }
 
+    /**
+     * This method is primarily meant to be used when you need to share connections between
+     * multiple *update* queries for a transaction
+     */
     static int update(Connection con, String QUERY, PreparedStatementValueSetter setter)
             throws SQLException, StorageQueryException {
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {

--- a/src/main/java/io/supertokens/storage/sql/QueryExecutorTemplate.java
+++ b/src/main/java/io/supertokens/storage/sql/QueryExecutorTemplate.java
@@ -27,7 +27,7 @@ public interface QueryExecutorTemplate {
 
     static <T> T execute(Start start, String QUERY, PreparedStatementValueSetter setter,
             ResultSetValueExtractor<T> mapper) throws SQLException, StorageQueryException {
-        return ConnectionPool.withConnection(start, con -> execute(con, QUERY, setter, mapper));
+        return ConnectionPool.withConnectionWithoutTransaction(start, con -> execute(con, QUERY, setter, mapper));
     }
 
     /**
@@ -48,7 +48,7 @@ public interface QueryExecutorTemplate {
 
     static int update(Start start, String QUERY, PreparedStatementValueSetter setter)
             throws SQLException, StorageQueryException {
-        return ConnectionPool.withConnection(start, con -> update(con, QUERY, setter));
+        return ConnectionPool.withConnectionWithoutTransaction(start, con -> update(con, QUERY, setter));
     }
 
     /**

--- a/src/main/java/io/supertokens/storage/sql/Start.java
+++ b/src/main/java/io/supertokens/storage/sql/Start.java
@@ -253,7 +253,7 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
 
     private <T> T startTransactionHelper(TransactionLogic<T> logic, TransactionIsolationLevel isolationLevel)
             throws StorageQueryException, StorageTransactionLogicException, SQLException {
-        return ConnectionPool.withConnectionForComplexTransaction(this, isolationLevel,
+        return ConnectionPool.withConnectionForTransaction(this, isolationLevel,
                 con -> logic.mainLogicAndCommit(new TransactionConnection(con)));
     }
 

--- a/src/main/java/io/supertokens/storage/sql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/sql/queries/GeneralQueries.java
@@ -21,6 +21,7 @@ import io.supertokens.pluginInterface.RECIPE_ID;
 import io.supertokens.pluginInterface.RowMapper;
 import io.supertokens.pluginInterface.authRecipe.AuthRecipeUserInfo;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
+import io.supertokens.pluginInterface.exceptions.StorageTransactionLogicException;
 import io.supertokens.storage.sql.ConnectionPool;
 import io.supertokens.storage.sql.Start;
 import io.supertokens.storage.sql.config.Config;
@@ -252,10 +253,14 @@ public class GeneralQueries {
 
     public static void setKeyValue(Start start, String key, KeyValueInfo info)
             throws SQLException, StorageQueryException {
-        ConnectionPool.withConnectionForTransaction(start, con -> {
-            setKeyValue_Transaction(start, con, key, info);
-            return null;
-        });
+        try {
+            ConnectionPool.withConnectionForTransaction(start, null, con -> {
+                setKeyValue_Transaction(start, con, key, info);
+                return null;
+            });
+        } catch (StorageTransactionLogicException e) {
+            throw new SQLException("Should never come here");
+        }
     }
 
     public static KeyValueInfo getKeyValue(Start start, String key) throws SQLException, StorageQueryException {

--- a/src/main/java/io/supertokens/storage/sql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/sql/queries/GeneralQueries.java
@@ -252,7 +252,7 @@ public class GeneralQueries {
 
     public static void setKeyValue(Start start, String key, KeyValueInfo info)
             throws SQLException, StorageQueryException {
-        ConnectionPool.withConnection(start, con -> {
+        ConnectionPool.withConnectionForTransaction(start, con -> {
             setKeyValue_Transaction(start, con, key, info);
             return null;
         });

--- a/src/main/java/io/supertokens/storage/sql/queries/PasswordlessQueries.java
+++ b/src/main/java/io/supertokens/storage/sql/queries/PasswordlessQueries.java
@@ -384,7 +384,7 @@ public class PasswordlessQueries {
 
     public static PasswordlessCode[] getCodesOfDevice(Start start, String deviceIdHash)
             throws StorageQueryException, SQLException {
-        return ConnectionPool.withConnection(start,
+        return ConnectionPool.withConnectionForTransaction(start,
                 con -> PasswordlessQueries.getCodesOfDevice_Transaction(start, con, deviceIdHash));
     }
 
@@ -419,7 +419,7 @@ public class PasswordlessQueries {
 
     public static PasswordlessCode getCodeByLinkCodeHash(Start start, String linkCodeHash)
             throws StorageQueryException, SQLException {
-        return ConnectionPool.withConnection(start,
+        return ConnectionPool.withConnectionForTransaction(start,
                 con -> PasswordlessQueries.getCodeByLinkCodeHash_Transaction(start, con, linkCodeHash));
     }
 

--- a/src/main/java/io/supertokens/storage/sql/queries/PasswordlessQueries.java
+++ b/src/main/java/io/supertokens/storage/sql/queries/PasswordlessQueries.java
@@ -384,8 +384,12 @@ public class PasswordlessQueries {
 
     public static PasswordlessCode[] getCodesOfDevice(Start start, String deviceIdHash)
             throws StorageQueryException, SQLException {
-        return ConnectionPool.withConnectionForTransaction(start,
-                con -> PasswordlessQueries.getCodesOfDevice_Transaction(start, con, deviceIdHash));
+        try {
+            return ConnectionPool.withConnectionForTransaction(start, null,
+                    con -> PasswordlessQueries.getCodesOfDevice_Transaction(start, con, deviceIdHash));
+        } catch (StorageTransactionLogicException e) {
+            throw new SQLException("Should never come here");
+        }
     }
 
     public static PasswordlessCode[] getCodesBefore(Start start, long time) throws StorageQueryException, SQLException {
@@ -419,8 +423,12 @@ public class PasswordlessQueries {
 
     public static PasswordlessCode getCodeByLinkCodeHash(Start start, String linkCodeHash)
             throws StorageQueryException, SQLException {
-        return ConnectionPool.withConnectionForTransaction(start,
-                con -> PasswordlessQueries.getCodeByLinkCodeHash_Transaction(start, con, linkCodeHash));
+        try {
+            return ConnectionPool.withConnectionForTransaction(start, null,
+                    con -> PasswordlessQueries.getCodeByLinkCodeHash_Transaction(start, con, linkCodeHash));
+        } catch (StorageTransactionLogicException e) {
+            throw new SQLException("Should never come here");
+        }
     }
 
     public static List<UserInfo> getUsersByIdList(Start start, List<String> ids)


### PR DESCRIPTION
all queries do not need a transaction
- add new function `withConnectionWithoutTransaction` for non transactional queries
- removed `withConnectionForTransaction` as redundant function
- refactored usages of `withConnectionForTransaction` to use `withConnectionForComplexTransaction`

