### PR TITLE
chore: mark non-implemented methods as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Migrates SessionInfo Queries to use Hibernate
 - Migrates Passwordless Queries to use Hibernate
 - Migrates JWTSigning Queries to use Hibernate
+- Mark Non-Implemented Methods with @Deprecated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,10 @@ Table `F`):
   the getter on that to get the primary key. Even the internal `.equals` function should use this manual getter
   function.
 - As an example, see the `PasswordResetTokensPk.java` code.
+
+### Deprecated Methods
+
+Since we maintain a Custom Wrapper over Session and Query interfaces, we allow only certain implementations to be 
+used.  
+Thus, many methods are marked as deprecated so that we can get IDE level assistance to ensure users do not use the 
+methods and find it failing at runtime.

--- a/src/main/java/io/supertokens/storage/sql/hibernate/CustomQueryWrapper.java
+++ b/src/main/java/io/supertokens/storage/sql/hibernate/CustomQueryWrapper.java
@@ -124,466 +124,559 @@ public class CustomQueryWrapper<R> implements Query<R> {
 //        throw new UnsupportedOperationException("Please use list(GetPrimaryKey<R> getPrimaryKeyFunc)");
 //    }
 
+    @Deprecated
     @Override
     public QueryProducer getProducer() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Optional<R> uniqueResultOptional() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Stream<R> stream() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> applyGraph(RootGraph graph, GraphSemantic semantic) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(Parameter<Instant> param, Instant value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(Parameter<LocalDateTime> param, LocalDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(Parameter<ZonedDateTime> param, ZonedDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(Parameter<OffsetDateTime> param, OffsetDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(String name, Instant value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(String name, LocalDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(String name, ZonedDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(String name, OffsetDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, Instant value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, LocalDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, ZonedDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, OffsetDateTime value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public ScrollableResults scroll() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public ScrollableResults scroll(ScrollMode scrollMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public R uniqueResult() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public FlushMode getHibernateFlushMode() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public CacheMode getCacheMode() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public String getCacheRegion() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Integer getFetchSize() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public LockOptions getLockOptions() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public String getComment() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public String getQueryString() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public RowSelection getQueryOptions() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public ParameterMetadata getParameterMetadata() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public String[] getNamedParameters() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public int getMaxResults() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setFirstResult(int startPosition) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public int getFirstResult() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setHint(String hintName, Object value) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Map<String, Object> getHints() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> Query<R> setParameter(Parameter<T> param, T value) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(Parameter<Date> param, Date value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(String name, Object val, Type type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(String name, Calendar value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(String name, Date value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, Object value) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, Calendar value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, Date value, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Set<Parameter<?>> getParameters() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Parameter<?> getParameter(String name) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> Parameter<T> getParameter(String name, Class<T> type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Parameter<?> getParameter(int position) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> Parameter<T> getParameter(int position, Class<T> type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isBound(Parameter<?> param) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T getParameterValue(Parameter<T> param) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Object getParameterValue(String name) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Object getParameterValue(int position) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> Query<R> setParameter(QueryParameter<T> parameter, T val) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <P> Query<R> setParameter(int position, P val, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <P> Query<R> setParameter(QueryParameter<P> parameter, P val, Type type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameter(int position, Object val, Type type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <P> Query<R> setParameter(QueryParameter<P> parameter, P val, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <P> Query<R> setParameter(String name, P val, TemporalType temporalType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setFlushMode(FlushModeType flushMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public FlushModeType getFlushMode() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public LockModeType getLockMode() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T unwrap(Class<T> cls) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setReadOnly(boolean readOnly) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Type[] getReturnTypes() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setHibernateFlushMode(FlushMode flushMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setCacheMode(CacheMode cacheMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isCacheable() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setCacheable(boolean cacheable) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setCacheRegion(String cacheRegion) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Integer getTimeout() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setTimeout(int timeout) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setFetchSize(int fetchSize) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isReadOnly() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setLockOptions(LockOptions lockOptions) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setLockMode(String alias, LockMode lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setComment(String comment) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> addQueryHint(String hint) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Iterator<R> iterate() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <P> Query<R> setParameterList(QueryParameter<P> parameter, Collection<P> values) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public org.hibernate.Query<R> setParameterList(int position, Collection values) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameterList(String name, Collection values, Type type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public org.hibernate.Query<R> setParameterList(int position, Collection values, Type type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setParameterList(String name, Object[] values, Type type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public org.hibernate.Query<R> setParameterList(int position, Object[] values, Type type) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public org.hibernate.Query<R> setParameterList(int position, Object[] values) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setProperties(Object bean) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setProperties(Map bean) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setEntity(int position, Object val) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setEntity(String name, Object val) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Type determineProperBooleanType(int position, Object value, Type defaultType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Type determineProperBooleanType(String name, Object value, Type defaultType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query<R> setResultTransformer(ResultTransformer transformer) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public String[] getReturnAliases() {
         throw new UnsupportedOperationException();

--- a/src/main/java/io/supertokens/storage/sql/hibernate/CustomSessionWrapper.java
+++ b/src/main/java/io/supertokens/storage/sql/hibernate/CustomSessionWrapper.java
@@ -267,651 +267,781 @@ public class CustomSessionWrapper implements Session {
     ////////////////////////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////////
     // UNSUPPORTED FUNCTIONS BELOW....................
+    @Deprecated
     @Override
     public void update(Object object) {
         throw new UnsupportedOperationException("Please use session.update(Class, Serializable, Object)");
     }
 
+    @Deprecated
     @Override
     public Serializable save(Object object) {
         throw new UnsupportedOperationException("Please use session.save(Class, Serializable, Object)");
     }
 
+    @Deprecated
     @Override
     public SharedSessionBuilder sessionWithOptions() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void flush() throws HibernateException {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setFlushMode(FlushModeType flushMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setFlushMode(FlushMode flushMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public FlushModeType getFlushMode() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void lock(Object entity, LockModeType lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void lock(Object entity, LockModeType lockMode, Map<String, Object> properties) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setHibernateFlushMode(FlushMode flushMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public FlushMode getHibernateFlushMode() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setCacheMode(CacheMode cacheMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public CacheMode getCacheMode() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public SessionFactory getSessionFactory() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void cancelQuery() throws HibernateException {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isDirty() throws HibernateException {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isDefaultReadOnly() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setDefaultReadOnly(boolean readOnly) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Serializable getIdentifier(Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean contains(String entityName, Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void evict(Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T load(Class<T> theClass, Serializable id, LockMode lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T load(Class<T> theClass, Serializable id, LockOptions lockOptions) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Object load(String entityName, Serializable id, LockMode lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Object load(String entityName, Serializable id, LockOptions lockOptions) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T load(Class<T> theClass, Serializable id) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Object load(String entityName, Serializable id) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void load(Object object, Serializable id) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void replicate(Object object, ReplicationMode replicationMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void replicate(String entityName, Object object, ReplicationMode replicationMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Serializable save(String entityName, Object object) {
         throw new UnsupportedOperationException("Please use session.save(Object) instead");
     }
 
+    @Deprecated
     @Override
     public void saveOrUpdate(Object object) {
         throw new UnsupportedOperationException("Please do not use this function. Instead use save or update");
     }
 
+    @Deprecated
     @Override
     public void saveOrUpdate(String entityName, Object object) {
         throw new UnsupportedOperationException("Please do not use this function. Instead use save or update");
     }
 
+    @Deprecated
     @Override
     public void update(String entityName, Object object) {
         throw new UnsupportedOperationException("Please use session.update(Object) instead");
     }
 
+    @Deprecated
     @Override
     public Object merge(Object object) {
         throw new UnsupportedOperationException("Please do not use this function. Instead use save or update");
     }
 
+    @Deprecated
     @Override
     public Object merge(String entityName, Object object) {
         throw new UnsupportedOperationException("Please do not use this function. Instead use save or update");
     }
 
+    @Deprecated
     @Override
     public void persist(Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void remove(Object entity) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T find(Class<T> entityClass, Object primaryKey) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T find(Class<T> entityClass, Object primaryKey, Map<String, Object> properties) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode, Map<String, Object> properties) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T getReference(Class<T> entityClass, Object primaryKey) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void persist(String entityName, Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void delete(Object object) {
         throw new UnsupportedOperationException("Use session.delete(Class, Serializable, Object)");
     }
 
+    @Deprecated
     @Override
     public void delete(String entityName, Object object) {
         throw new UnsupportedOperationException("Please use delete(Object)");
     }
 
+    @Deprecated
     @Override
     public void lock(Object object, LockMode lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void lock(String entityName, Object object, LockMode lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public LockRequest buildLockRequest(LockOptions lockOptions) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(Object entity, Map<String, Object> properties) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(Object entity, LockModeType lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(Object entity, LockModeType lockMode, Map<String, Object> properties) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(String entityName, Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(Object object, LockMode lockMode) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(Object object, LockOptions lockOptions) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void refresh(String entityName, Object object, LockOptions lockOptions) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public LockMode getCurrentLockMode(Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Query createFilter(Object collection, String queryString) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void clear() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void detach(Object entity) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public LockModeType getLockMode(Object entity) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setProperty(String propertyName, Object value) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Map<String, Object> getProperties() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T get(Class<T> entityType, Serializable id, LockOptions lockOptions) {
         throw new UnsupportedOperationException("Please use session.get(..., LockMode) instead");
     }
 
+    @Deprecated
     @Override
     public Object get(String entityName, Serializable id) {
         throw new UnsupportedOperationException("Please use session.get(Class<T>, ....) instead");
     }
 
+    @Deprecated
     @Override
     public Object get(String entityName, Serializable id, LockMode lockMode) {
         throw new UnsupportedOperationException("Please use session.get(Class<T>, ....) instead");
     }
 
+    @Deprecated
     @Override
     public Object get(String entityName, Serializable id, LockOptions lockOptions) {
         throw new UnsupportedOperationException("Please use session.get(Class<T>, ....) instead");
     }
 
+    @Deprecated
     @Override
     public String getEntityName(Object object) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public IdentifierLoadAccess byId(String entityName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> MultiIdentifierLoadAccess<T> byMultipleIds(Class<T> entityClass) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public MultiIdentifierLoadAccess byMultipleIds(String entityName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> IdentifierLoadAccess<T> byId(Class<T> entityClass) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public NaturalIdLoadAccess byNaturalId(String entityName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> NaturalIdLoadAccess<T> byNaturalId(Class<T> entityClass) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public SimpleNaturalIdLoadAccess bySimpleNaturalId(String entityName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> SimpleNaturalIdLoadAccess<T> bySimpleNaturalId(Class<T> entityClass) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Filter enableFilter(String filterName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Filter getEnabledFilter(String filterName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void disableFilter(String filterName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public SessionStatistics getStatistics() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isReadOnly(Object entityOrProxy) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setReadOnly(Object entityOrProxy, boolean readOnly) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> RootGraph<T> createEntityGraph(Class<T> rootType) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public RootGraph<?> createEntityGraph(String graphName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public RootGraph<?> getEntityGraph(String graphName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Connection disconnect() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void reconnect(Connection connection) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isFetchProfileEnabled(String name) throws UnknownProfileException {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void enableFetchProfile(String name) throws UnknownProfileException {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void disableFetchProfile(String name) throws UnknownProfileException {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public TypeHelper getTypeHelper() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public LobHelper getLobHelper() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void addEventListeners(SessionEventListener... listeners) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public org.hibernate.query.Query createNamedQuery(String name) {
         throw new UnsupportedOperationException("Please use session.createQuery instead");
     }
 
+    @Deprecated
     @Override
     public <T> org.hibernate.query.Query<T> createQuery(CriteriaQuery<T> criteriaQuery) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public org.hibernate.query.Query createQuery(CriteriaUpdate updateQuery) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public org.hibernate.query.Query createQuery(CriteriaDelete deleteQuery) {
         throw new UnsupportedOperationException("Please use session.createQuery instead");
     }
 
+    @Deprecated
     @Override
     public <T> org.hibernate.query.Query<T> createNamedQuery(String name, Class<T> resultType) {
         throw new UnsupportedOperationException("Please use session.createQuery instead");
     }
 
+    @Deprecated
     @Override
     public NativeQuery createNativeQuery(String sqlString, Class resultClass) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public StoredProcedureQuery createNamedStoredProcedureQuery(String name) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public StoredProcedureQuery createStoredProcedureQuery(String procedureName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public StoredProcedureQuery createStoredProcedureQuery(String procedureName, Class... resultClasses) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public StoredProcedureQuery createStoredProcedureQuery(String procedureName, String... resultSetMappings) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void joinTransaction() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public <T> T unwrap(Class<T> cls) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Object getDelegate() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public EntityManagerFactory getEntityManagerFactory() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public CriteriaBuilder getCriteriaBuilder() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Metamodel getMetamodel() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public NativeQuery createSQLQuery(String queryString) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public NativeQuery createNativeQuery(String sqlString) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public NativeQuery createNativeQuery(String sqlString, String resultSetMapping) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public NativeQuery getNamedNativeQuery(String name) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Session getSession() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public String getTenantIdentifier() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isOpen() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public boolean isConnected() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Transaction beginTransaction() {
         throw new UnsupportedOperationException("Please use beginTransaction(isolationLevel) function instead");
     }
 
+    @Deprecated
     @Override
     public org.hibernate.query.Query getNamedQuery(String queryName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public ProcedureCall getNamedProcedureCall(String name) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public ProcedureCall createStoredProcedureCall(String procedureName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public ProcedureCall createStoredProcedureCall(String procedureName, Class... resultClasses) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public ProcedureCall createStoredProcedureCall(String procedureName, String... resultSetMappings) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Criteria createCriteria(Class persistentClass) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Criteria createCriteria(Class persistentClass, String alias) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Criteria createCriteria(String entityName) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Criteria createCriteria(String entityName, String alias) {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public Integer getJdbcBatchSize() {
         throw new UnsupportedOperationException();
     }
 
+    @Deprecated
     @Override
     public void setJdbcBatchSize(Integer jdbcBatchSize) {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
Since we maintain a Custom Wrapper over Session and Query interfaces, we allow only certain implementations to be used.  

Thus, many methods are marked as deprecated so that we can get IDE-level assistance to ensure users do not use the methods and find them failing at runtime.